### PR TITLE
Fix stdout/stderr buffering on Windows

### DIFF
--- a/src/execShell.ts
+++ b/src/execShell.ts
@@ -31,22 +31,26 @@ export function execShell(
   }
 
   if (os.platform() === "win32") {
-    const spawnProcess = spawn(file, args ?? [], { ...options, shell: true });
-    process = spawnProcess;
+    process = spawn(file, args ?? [], { ...options, shell: true });
+    var stdoutBuffers: Buffer[] = [];
+    process.stdout?.on('data', (data) => { stdoutBuffers.push(data); });
 
-    spawnProcess.on("error", async (error) => {
+    var stderrBuffers: Buffer[] = [];
+    process.stderr?.on('data', (data) => { stderrBuffers.push(data); });
+
+    process.on("error", async (error) => {
       currentlyRunningChildProcesses.delete(process);
       processHandler(
         error,
-        spawnProcess.stdout,
-        await bufferFromReadableStream(spawnProcess.stderr)
+        Buffer.concat(stdoutBuffers).toString(),
+        Buffer.concat(stderrBuffers)
       );
     });
-    spawnProcess.on("close", async () => {
+    process.on("close", () => {
       processHandler(
         null,
-        spawnProcess.stdout,
-        await bufferFromReadableStream(spawnProcess.stderr)
+        Buffer.concat(stdoutBuffers).toString(),
+        Buffer.concat(stderrBuffers)
       );
     });
   } else {

--- a/src/execShell.ts
+++ b/src/execShell.ts
@@ -39,7 +39,6 @@ export function execShell(
     process.stderr?.on('data', (data) => { stderrBuffers.push(data); });
 
     process.on("error", async (error) => {
-      currentlyRunningChildProcesses.delete(process);
       processHandler(
         error,
         Buffer.concat(stdoutBuffers).toString(),


### PR DESCRIPTION
From the spawn documentation, the process can be starved if no one is reading its stdout/stderr, so attach a handler for this purpose. This also ensures that types end up as expected by `processHandler`.