### PR TITLE
Fixed "no lintable files found" error when navigating to Swift interface files

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -53,6 +53,11 @@ export async function diagnosticsForDocument(request: {
     return [];
   }
 
+  // Skip linting if the user navigates to a system framework interface file.
+  if (request.document.uri.fsPath.includes(".swiftinterface")) {
+    return [];
+  }
+
   const workspaceOrRoot =
     request.workspaceFolder?.uri.fsPath ?? path.normalize("/");
   const relativeDocumentPath = path.relative(


### PR DESCRIPTION
I'm using the [xcode-build-server](https://github.com/SolaWing/xcode-build-server) project to work with Xcode projects in VS Code. Whenever I to navigate to a symbol (Cmd + Click) inside a Swift framework (e.g. `JSONDecoder` or `UUID`), SwiftLint throws the following error:

```
2
cd /Users/felix/Developer/Swift/Apps/TelemetryViewer &&  SCRIPT_INPUT_FILE_0='../../../../../../var/folders/ms/lrk4_z852q595bcwwfh0ftcm0000gn/T/GeneratedInterfaces/Foundation.swiftinterface' SCRIPT_INPUT_FILE_COUNT='1' '/opt/homebrew/bin/swiftlint'  'lint' '--use-script-input-files' '--quiet' '--reporter' 'json'
extensionHostProcess.js:147
Error: Unexpected SIGPIPE
	at process.<anonymous> (/Applications/Visual Studio Code.app/Contents/Resources/app/out/bootstrap.js:1:471)
	at process.emit (/Users/felix/Developer/Misc/VS Code Plugins/vscode-swiftlint/lib/events.js:513:28)
	at Signal.callbackTrampoline (node:internal/async_hooks:130:17) {stack: 'Error: Unexpected SIGPIPE
	at process.<anonym…Trampoline (node:internal/async_hooks:130:17)', message: 'Unexpected SIGPIPE'}

extensionHostProcess.js:147
2
stderr Error: No lintable files found at paths: ''
```

In this example, the lintable file path (`request.document.uri.fsPath`) contains the following value: `/var/folders/ms/lrk4_z852q595bcwwfh0ftcm0000gn/T/GeneratedInterfaces/Foundation.swiftinterface`

Since I don't see any reason to run SwiftLint on read-only system framework files, I've added a check to skip `.swiftinterface` files.

**Note:** This is my first time working on VS Code plugins. Please feel free to make edits to my code. 😊