### PR TITLE
docs: onlyEnableWithConfig requires configSearchPaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ let package = Package(
 
 ## Configuration
 
-| Config                                  | Type       | Default                    | Description                                                                                                                             |
-| --------------------------------------- | ---------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `swiftlint.enable`                      | `Bool`     | `true`                     | Whether SwiftLint should actually do something.                                                                                         |
-| `swiftlint.onlyEnableOnSwiftPMProjects` | `Bool`     | `false`                    | Requires and uses a SwiftLint as SwiftPM dependency.                                                                                    |
-| `swiftlint.onlyEnableWithConfig`        | `Bool`     | `false`                    | Only lint if config present.                                                                                                            |
-| `swiftlint.path`                        | `String`   | `swiftlint`                | The location of the globally installed SwiftLint (resolved with the current path if only a filename).                                   |
-| `swiftlint.additionalParameters`        | `[String]` | `[]`                       | Additional parameters to pass to SwiftLint.                                                                                             |
-| `swiftlint.configSearchPaths`           | `[String]` | `[]`                       | Possible paths for SwiftLint config. _This disables [nested configurations](https://github.com/realm/SwiftLint#nested-configurations)!_ |
-| `swiftlint.autoLintWorkspace`           | `Bool`     | `true`                     | Automatically lint the whole project right after start.                                                                                 |
+| Config                                  | Type       | Default     | Description                                                                                                                             |
+| --------------------------------------- | ---------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `swiftlint.enable`                      | `Bool`     | `true`      | Whether SwiftLint should actually do something.                                                                                         |
+| `swiftlint.onlyEnableOnSwiftPMProjects` | `Bool`     | `false`     | Requires and uses a SwiftLint as SwiftPM dependency.                                                                                    |
+| `swiftlint.onlyEnableWithConfig`        | `Bool`     | `false`     | Only lint if config present. Requires `swiftlint.configSearchPaths`.                                                                    |
+| `swiftlint.path`                        | `String`   | `swiftlint` | The location of the globally installed SwiftLint (resolved with the current path if only a filename).                                   |
+| `swiftlint.additionalParameters`        | `[String]` | `[]`        | Additional parameters to pass to SwiftLint.                                                                                             |
+| `swiftlint.configSearchPaths`           | `[String]` | `[]`        | Possible paths for SwiftLint config. _This disables [nested configurations](https://github.com/realm/SwiftLint#nested-configurations)!_ |
+| `swiftlint.autoLintWorkspace`           | `Bool`     | `true`      | Automatically lint the whole project right after start.                                                                                 |
 
 ## Commands
 
@@ -68,10 +68,6 @@ To automatically fix all issues within a document on save, add the following to 
   }
 }
 ```
-
-## Contributors
-
-- Valentin Knabel, [@vknabel](https://github.com/vknabel), [@vknabel](https://twitter.com/vknabel) on Twitter
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "swiftlint.onlyEnableWithConfig": {
           "type": "boolean",
           "default": false,
-          "description": "Only use SwiftLint when a config exists."
+          "description": "Only use SwiftLint when a config exists. Requires `swiftlint.configSearchPaths`."
         },
         "swiftlint.path": {
           "description": "The location of your globally installed SwiftLint.",


### PR DESCRIPTION
Documents the requirement to avoid confusion #82 

Reasoning behind this: if we do not know where to find the configs, we cannot check if they are present.