### PR TITLE
feat: source.fixAll.swiftlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,23 +41,24 @@ let package = Package(
 
 ## Configuration
 
-| Config                                  | Type       | Default                    | Description                                                                                                                             |
-| --------------------------------------- | ---------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `swiftlint.enable`                      | `Bool`     | `true`                     | Whether SwiftLint should actually do something.                                                                                         |
-| `swiftlint.onlyEnableOnSwiftPMProjects` | `Bool`     | `false`                    | Requires and uses a SwiftLint as SwiftPM dependency.                                                                                    |
-| `swiftlint.onlyEnableWithConfig`        | `Bool`     | `false`                    | Only lint if config present.                                                                                                            |
-| `swiftlint.path`                        | `String`   | `swiftlint`                | The location of the globally installed SwiftLint (resolved with the current path if only a filename).                                   |
-| `swiftlint.additionalParameters`        | `[String]` | `[]`                       | Additional parameters to pass to SwiftLint.                                                                                             |
-| `swiftlint.configSearchPaths`           | `[String]` | `[]`                       | Possible paths for SwiftLint config. _This disables [nested configurations](https://github.com/realm/SwiftLint#nested-configurations)!_ |
-| `swiftlint.autoLintWorkspace`           | `Bool`     | `true`                     | Automatically lint the whole project right after start.                                                                                 |
+| Config                                  | Type       | Default     | Description                                                                                                                             |
+| --------------------------------------- | ---------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `swiftlint.enable`                      | `Bool`     | `true`      | Whether SwiftLint should actually do something.                                                                                         |
+| `swiftlint.onlyEnableOnSwiftPMProjects` | `Bool`     | `false`     | Requires and uses a SwiftLint as SwiftPM dependency.                                                                                    |
+| `swiftlint.onlyEnableWithConfig`        | `Bool`     | `false`     | Only lint if config present.                                                                                                            |
+| `swiftlint.path`                        | `String`   | `swiftlint` | The location of the globally installed SwiftLint (resolved with the current path if only a filename).                                   |
+| `swiftlint.additionalParameters`        | `[String]` | `[]`        | Additional parameters to pass to SwiftLint.                                                                                             |
+| `swiftlint.configSearchPaths`           | `[String]` | `[]`        | Possible paths for SwiftLint config. _This disables [nested configurations](https://github.com/realm/SwiftLint#nested-configurations)!_ |
+| `swiftlint.autoLintWorkspace`           | `Bool`     | `true`      | Automatically lint the whole project right after start.                                                                                 |
 
 ## Commands
 
-| Short Title               | Command                   |
-| ------------------------- | ------------------------- |
-| SwiftLint: Lint workspace | `swiftlint.lintWorkspace` |
-| SwiftLint: Fix workspace  | `swiftlint.fixWorkspace`  |
-| SwiftLint: Fix document   | `swiftlint.fixDocument`   |
+| Short Title                     | Command                   |
+| ------------------------------- | ------------------------- |
+| SwiftLint: Lint workspace       | `swiftlint.lintWorkspace` |
+| SwiftLint: Fix workspace        | `swiftlint.fixWorkspace`  |
+| SwiftLint: Fix document         | `swiftlint.fixDocument`   |
+| SwiftLint: Fix all known issues | `source.fixAll.swiftlint` |
 
 To automatically fix all issues within a document on save, add the following to your `.vscode/settings.json`:
 

--- a/package.json
+++ b/package.json
@@ -120,6 +120,11 @@
         "title": "SwiftLint: Fix all autocorrect issues in document",
         "command": "swiftlint.fixDocument",
         "shortTitle": "SwiftLint: Fix document"
+      },
+      {
+        "title": "SwiftLint: Fix all known autocorrect issues",
+        "command": "source.fixAll.swiftlint",
+        "shortTitle": "SwiftLint: Fix all known issues"
       }
     ]
   },

--- a/src/Current.ts
+++ b/src/Current.ts
@@ -20,6 +20,7 @@ export interface Current {
     lintWorkspace: string;
     fixWorkspace: string;
     fixDocument: string;
+    fixAll: string;
   };
   config: {
     isEnabled(): boolean;
@@ -80,6 +81,7 @@ export function prodEnvironment(): Current {
       lintWorkspace: "swiftlint.lintWorkspace",
       fixWorkspace: "swiftlint.fixWorkspace",
       fixDocument: "swiftlint.fixDocument",
+      fixAll: "source.fixAll.swiftlint",
     },
     config: {
       affectsConfiguration: (changeEvent: vscode.ConfigurationChangeEvent) =>

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -53,7 +53,10 @@ export async function diagnosticsForDocument(request: {
     return [];
   }
 
-  if (!request.document.uri.fsPath || request.document.uri.fsPath.includes(".swiftinterface")) {
+  if (
+    !request.document.uri.fsPath ||
+    request.document.uri.fsPath.includes(".swiftinterface")
+  ) {
     return [];
   }
 
@@ -180,7 +183,7 @@ export async function diagnosticsForFolder(request: {
       ? []
       : await filterAsync(allFiles, (path) => config.includes(path))
     : request.parameters || [];
-  if (includedFiles.length === 0) {
+  if (includedFiles.length === 0 && config != null) {
     return new Map();
   }
 


### PR DESCRIPTION
Closes #81 

Implements `source.fixAll.swiftlint` which behaves similar to all other linter extensions.

Also parallelizes fixing single documents and fixes an issue that could lead SwiftLint to not lint anything.