### PR TITLE
Make swiftlint.path possible to set locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/vknabel/vscode-swiftlint"
   },
-  "version": "1.8.4",
+  "version": "1.8.5",
   "license": "MIT",
   "author": {
     "name": "Valentin Knabel",
@@ -38,6 +38,15 @@
     "workspaceContains:**/*swift"
   ],
   "main": "./out/extension.js",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "Since the SwiftLint path is used to execute SwiftLint, it must be trusted.",
+      "restrictedConfigurations": [
+        "swiftlint.path"
+      ]
+    }
+  },
   "contributes": {
     "configuration": {
       "title": "SwiftLint configuration",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,7 @@
           "description": "Only use SwiftLint when a config exists. Requires `swiftlint.configSearchPaths`."
         },
         "swiftlint.path": {
-          "description": "The location of your globally installed SwiftLint.",
-          "scope": "machine",
+          "description": "The location of your globally or locally installed SwiftLint.",
           "default": "swiftlint",
           "oneOf": [
             {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         },
         "swiftlint.path": {
           "description": "The location of your globally or locally installed SwiftLint.",
+          "scope": "machine-overridable",
           "default": "swiftlint",
           "oneOf": [
             {


### PR DESCRIPTION
Closes #101. Tried it out locally and it seems to work as expected with this small change.

Makes the plugin more flexible:
- Works with any folder structure
- Supports local installation with not on Swift PM but for example with Cocoapods
