### PR TITLE
Build package only when required by configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ let package = Package(
         .package(url: "https://github.com/orta/PackageConfig.git", from: "0.0.1"),
         // Dev deps
         .package(url: "https://github.com/orta/Komondor.git", from: "0.0.1"),
-+        .package(url: "https://github.com/realm/SwiftLint.git", from: "0.37.0"),
++        .package(url: "https://github.com/realm/SwiftLint.git", from: "0.58.2"),
     ],
     targets: [...]
 )
@@ -44,12 +44,18 @@ let package = Package(
 | Config                                  | Type       | Default     | Description                                                                                                                             |
 | --------------------------------------- | ---------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `swiftlint.enable`                      | `Bool`     | `true`      | Whether SwiftLint should actually do something.                                                                                         |
-| `swiftlint.onlyEnableOnSwiftPMProjects` | `Bool`     | `false`     | Requires and uses a SwiftLint as SwiftPM dependency.                                                                                    |
+| `swiftlint.onlyEnableOnSwiftPMProjects` | `Bool`     | `false`     | Requires and uses a SwiftLint as SwiftPM dependency. This will cause the extension to build the Swift package upon first launch.        |
 | `swiftlint.onlyEnableWithConfig`        | `Bool`     | `false`     | Only lint if config present. Requires `swiftlint.configSearchPaths`.                                                                    |
 | `swiftlint.path`                        | `String`   | `swiftlint` | The location of the globally installed SwiftLint (resolved with the current path if only a filename).                                   |
 | `swiftlint.additionalParameters`        | `[String]` | `[]`        | Additional parameters to pass to SwiftLint.                                                                                             |
 | `swiftlint.configSearchPaths`           | `[String]` | `[]`        | Possible paths for SwiftLint config. _This disables [nested configurations](https://github.com/realm/SwiftLint#nested-configurations)!_ |
 | `swiftlint.autoLintWorkspace`           | `Bool`     | `true`      | Automatically lint the whole project right after start.                                                                                 |
+
+Note that when `swiftlint.onlyEnableOnSwiftPMProjects` is enabled, the extension will only run `swiftlint` executables
+built as part of the Swift package open in the workspace. It will try to build the binary once on first launch. If
+the build fails, the extension will not fall back to a globally installed `swiftlint`. If you prefer a
+locally built `swiftlint`, but want to skip the automatic initial build, let `swiftlint.path` point to the local
+executable you have built manually or by other means independent of the extension.
 
 ## Commands
 

--- a/src/Current.ts
+++ b/src/Current.ts
@@ -109,17 +109,19 @@ export function prodEnvironment(): Current {
         }
 
         // Support running from Swift PM projects
-        const possibleLocalPaths = glob.sync(
-          "**/.build/{release,debug}/swiftlint",
-          { maxDepth: 5 }
-        );
-        for (const path of possibleLocalPaths) {
-          const fullPath = workspace
+        if (Current.config.onlyEnableOnSwiftPMProjects()) {
+          const possibleLocalPaths = glob.sync(
+            "**/.build/{release,debug}/swiftlint",
+            { maxDepth: 5 }
+          );
+          for (const path of possibleLocalPaths) {
+            const fullPath = workspace
             ? paths.resolve(workspace!.uri.path, path)
             : path;
 
-          if (existsSync(fullPath)) {
-            return [absolutePath(fullPath)];
+            if (existsSync(fullPath)) {
+              return [absolutePath(fullPath)];
+            }
           }
         }
 
@@ -160,11 +162,7 @@ export function prodEnvironment(): Current {
 }
 
 const fallbackGlobalSwiftLintPath = (): string[] | null => {
-  if (
-    vscode.workspace
-      .getConfiguration()
-      .get("swiftlint.onlyEnableOnSwiftPMProjects", false)
-  ) {
+  if (Current.config.onlyEnableOnSwiftPMProjects()) {
     return null;
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,9 @@ export function deactivate(_context: vscode.ExtensionContext) {
 }
 
 async function buildSwiftlintIfNeeded() {
+  if (!Current.config.onlyEnableOnSwiftPMProjects()) {
+    return;
+  }
   const manifests = await vscode.workspace.findFiles(
     "**/Package.swift",
     "**/.build/**",


### PR DESCRIPTION
Currently, whenever I open a workspace, the extension needs an unreasonable amount of time to build `swiftlint` in release mode, blocking other activity on the Swift package from progressing.

Taking the locally built binary is a nice feature, yet the overhead doesn't justify the benefit. Also, I found it quite surprising that the local version was preferred over the globally installed `swiftlint` binary even though I configured `swiftlint.path` specifically.

I think that restricting all this to `swiftlint.onlyEnableOnSwiftPMProjects` makes sense. If you enable it now, the extension makes sure to build the package and restricts itself to the local binary ignoring `swiftlint.path`.

This also resolves #99, I assume.